### PR TITLE
Tree-shaking fix by using ESM export rather than commonjs exports

### DIFF
--- a/src/button-styles.js
+++ b/src/button-styles.js
@@ -2,6 +2,4 @@ const red = "color: red;";
 const blue = "color: blue;";
 const makeColorStyle = color => `color: ${color};`;
 
-exports.red = red;
-exports.blue = blue;
-exports.makeColorStyle = makeColorStyle;
+export {red, blue, makeColorStyle}

--- a/src/button.js
+++ b/src/button.js
@@ -8,4 +8,4 @@ const makeButton = buttonName => {
   return `Button: ${buttonName}`;
 };
 
-module.exports = makeButton;
+export default makeButton


### PR DESCRIPTION
I don't think 'exports' keyword can be used for treeshaking. So, this patch will fix 'feature/031-all-module-type'.