### PR TITLE
Update webpack-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url-loader": "^1.0.1",
     "webpack": "^4.8.0",
     "webpack-bundle-analyzer": "^2.11.1",
-    "webpack-cli": "^2.1.3",
+    "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.1.2",
     "webpack-node-externals": "^1.7.2",


### PR DESCRIPTION
When doing `npm run dev` on this branch, got error 
```describe: optionsSchema.definitions.output.properties.path.description,```

Updating webpack-cli fixes this.