### PR TITLE
webpackMerge function is deprecated in webpack-merge 5.x.x.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const webpackMerge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 
 const modeConfig = env => require(`./build-utils/webpack.${env}`)(env);
 
 module.exports = ({ mode, presets } = { mode: "production", presets: [] }) => {
-  return webpackMerge(
+  return merge(
     {
       mode,
       output: {


### PR DESCRIPTION
webpack-merge updated it's api in version 5.x.x. If following along in the course, the npm install would download version 5.x.x, where instead of using default require of webpackMerge it has to be updated to name import merge.

I have updated the webpack config file.

So, instead of const ```webpackMerge = require("webpack-merge");```
we should write ```{ merge } = require("webpack-merge");```

To keep it similar to how Sean does it in the video, use version 4.x.x